### PR TITLE
Update metadata.json

### DIFF
--- a/auto-brightness-toggle@sao.studio/metadata.json
+++ b/auto-brightness-toggle@sao.studio/metadata.json
@@ -5,6 +5,6 @@
   "url": "https://github.com/m1nicrusher/auto-brightness-toggle",
   "version": 2,
   "shell-version": [
-    "43"
+    "43", "44"
   ]
 }


### PR DESCRIPTION
Making the extension Gnome 44 compatible.

Also see https://github.com/m1nicrusher/auto-brightness-toggle/issues/2