### PR TITLE
Fix "Main.panel.statusArea.quickSettings._brightness is undefined"

### DIFF
--- a/auto-brightness-toggle@sao.studio/extension.js
+++ b/auto-brightness-toggle@sao.studio/extension.js
@@ -19,6 +19,7 @@
  */
 
 import Gio from "gi://Gio";
+import GLib from 'gi://GLib';
 import GObject from "gi://GObject";
 import St from "gi://St";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
@@ -96,6 +97,19 @@ export default class AutoBrightnessToggleExtension extends Extension {
     }
 
     enable() {
+        if (Main.panel.statusArea.quickSettings._brightness)
+            this._enable();
+        else
+            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+                if (!Main.panel.statusArea.quickSettings._brightness)
+                    return GLib.SOURCE_CONTINUE;
+
+                this._enable();
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    _enable() {
         // If auto brightness is not supported, throw error 
         if (!this.isAutoBrightnessSupported()) {
             throw new Error("Auto brightness is not supported on this system. \n" +


### PR DESCRIPTION
The quick settings menu can be populated after the extension is loaded. On my computer, I was getting the
`Main.panel.statusArea.quickSettings._brightness is undefined` error whenever gnome-shell was restarted, and I had to re-install the extension for it to work.

Fix adapted from
https://discourse.gnome.org/t/main-panel-statusarea-quicksettings-system-is-undefined/16827/2

Tested on GNOME 47